### PR TITLE
Set async search max results to 50, from 10

### DIFF
--- a/extensions/bundles/europeana/selectasync/src/Controller/SelectAsyncController.php
+++ b/extensions/bundles/europeana/selectasync/src/Controller/SelectAsyncController.php
@@ -485,7 +485,7 @@ class SelectAsyncController implements ControllerProviderInterface
                 break;
         }
 
-        $qb->setMaxResults(10);
+        $qb->setMaxResults(50);
 
         $entries = $qb->execute()->fetchAll();
 


### PR DESCRIPTION
Fixes issue with searching persons when more than 10 exist.